### PR TITLE
fix(clarify): add missing skills field to plugin.json

### DIFF
--- a/plugins/clarify/.claude-plugin/plugin.json
+++ b/plugins/clarify/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "repository": "https://github.com/team-attention/plugins-for-claude-natives",
   "license": "MIT",
-  "keywords": ["claude-code", "plugin", "requirements", "clarification", "known-unknown", "strategy", "metamedium", "content-form"]
+  "keywords": ["claude-code", "plugin", "requirements", "clarification", "known-unknown", "strategy", "metamedium", "content-form"],
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Problem

After installing the `clarify` plugin, the three skills (`vague`, `unknown`, `metamedium`) are not registered and cannot be used via the `Skill` tool.

## Root Cause

`plugin.json` is missing the `"skills"` declaration. The plugin loader uses this field to discover the skills directory. Without it, even though the skill files exist under `skills/`, they are never loaded.

Comparison with a working plugin (`ouroboros`):
```json
// ouroboros plugin.json ✓
"skills": "./skills/"

// clarify plugin.json ✗ (missing)
```

## Fix

Add `"skills": "./skills/"` to `plugins/clarify/.claude-plugin/plugin.json`.

## Test

After the fix, running `/reload-plugins` should register `clarify:vague`, `clarify:unknown`, and `clarify:metamedium` skills.